### PR TITLE
Add support for PostgreSQL 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,19 @@ jobs:
       fail-fast: false
       matrix:
         id:
+          - "alpine-15"
           - "alpine-14"
           - "alpine-13"
           - "alpine-12"
           - "alpine-11"
           - "alpine-10"
+          - "alpine-15-slim"
           - "alpine-14-slim"
           - "alpine-13-slim"
           - "alpine-12-slim"
           - "alpine-11-slim"
           - "alpine-10-slim"
+          - "debian-15"
           - "debian-14"
           - "debian-13"
           - "debian-12"

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -1,0 +1,41 @@
+FROM postgres:15-alpine
+
+RUN \
+  apk --no-cache add \
+    build-base \
+    clang-dev \
+    llvm13 \
+    lz4-dev \
+    msgpack-c-dev \
+    zstd-dev
+
+ENV PGROONGA_VERSION=2.4.1 \
+    GROONGA_VERSION=12.0.9
+
+RUN \
+  mkdir build && \
+  cd build && \
+  wget https://packages.groonga.org/source/pgroonga/pgroonga-${PGROONGA_VERSION}.tar.gz && \
+  tar xf pgroonga-${PGROONGA_VERSION}.tar.gz && \
+  wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz && \
+  tar xf groonga-${GROONGA_VERSION}.tar.gz -C pgroonga-${PGROONGA_VERSION}/vendor && \
+  cd pgroonga-${PGROONGA_VERSION}/vendor/groonga-${GROONGA_VERSION} && \
+  ./configure && \
+  make -j$(nproc) && \
+  make install && \
+  cd ../../ && \
+  make HAVE_MSGPACK=1 -j$(nproc) && \
+  make install
+
+FROM postgres:15-alpine
+
+# copy thirdpart lib files
+COPY --from=0 /usr/lib/libmsgpackc.so.2 /usr/lib/
+COPY --from=0 /usr/lib/liblz4.so.1 /usr/lib/
+COPY --from=0 /usr/lib/libzstd.so.1 /usr/lib/
+# copy Groonga lib files
+COPY --from=0 /usr/local/lib/libgroonga.so.0 /usr/local/lib/
+COPY --from=0 /usr/local/lib/groonga/ /usr/local/lib/groonga/
+# copy PGroonga extension files
+COPY --from=0 /usr/local/lib/postgresql/pgroonga.so /usr/local/lib/postgresql/pgroonga_check.so /usr/local/lib/postgresql/pgroonga_database.so /usr/local/lib/postgresql/
+COPY --from=0 /usr/local/share/postgresql/extension/pgroonga* /usr/local/share/postgresql/extension/

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -37,5 +37,5 @@ COPY --from=0 /usr/lib/libzstd.so.1 /usr/lib/
 COPY --from=0 /usr/local/lib/libgroonga.so.0 /usr/local/lib/
 COPY --from=0 /usr/local/lib/groonga/ /usr/local/lib/groonga/
 # copy PGroonga extension files
-COPY --from=0 /usr/local/lib/postgresql/pgroonga.so /usr/local/lib/postgresql/pgroonga_check.so /usr/local/lib/postgresql/pgroonga_database.so /usr/local/lib/postgresql/
+COPY --from=0 /usr/local/lib/postgresql/pgroonga*.so /usr/local/lib/postgresql/
 COPY --from=0 /usr/local/share/postgresql/extension/pgroonga* /usr/local/share/postgresql/extension/

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -1,0 +1,37 @@
+FROM postgres:15-alpine
+
+RUN \
+  apk --no-cache add \
+    build-base \
+    clang-dev \
+    llvm13 \
+    lz4-dev \
+    msgpack-c-dev \
+    zstd-dev
+
+ENV PGROONGA_VERSION=2.4.1 \
+    GROONGA_VERSION=12.0.9
+
+RUN \
+  mkdir build && \
+  cd build && \
+  wget https://packages.groonga.org/source/pgroonga/pgroonga-${PGROONGA_VERSION}.tar.gz && \
+  tar xf pgroonga-${PGROONGA_VERSION}.tar.gz && \
+  wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz && \
+  tar xf groonga-${GROONGA_VERSION}.tar.gz -C pgroonga-${PGROONGA_VERSION}/vendor && \
+  cd pgroonga-${PGROONGA_VERSION}/vendor/groonga-${GROONGA_VERSION} && \
+  ./configure && \
+  make -j$(nproc) && \
+  make install && \
+  cd ../../ && \
+  make HAVE_MSGPACK=1 -j$(nproc) && \
+  make install && \
+  cd ../ && \
+  rm -rf build
+
+RUN \
+  apk del \
+    build-base \
+    clang \
+    clang-dev \
+    llvm13

--- a/debian/15/Dockerfile
+++ b/debian/15/Dockerfile
@@ -1,0 +1,17 @@
+FROM postgres:15-bullseye
+
+ENV PGROONGA_VERSION=2.4.1-1
+RUN \
+  apt update && \
+  apt upgrade -y -V && \
+  apt install -y -V wget && \
+  wget https://packages.groonga.org/debian/groonga-apt-source-latest-bullseye.deb && \
+  apt install -y -V ./groonga-apt-source-latest-bullseye.deb && \
+  rm groonga-apt-source-latest-bullseye.deb && \
+  apt update && \
+  apt install -y -V \
+    postgresql-15-pgdg-pgroonga=${PGROONGA_VERSION} \
+    groonga-normalizer-mysql \
+    groonga-tokenizer-mecab && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
GitHub: fix GH-13

I have tested whether we can build images and use PGroonga in them by the following procedure.

Build an image and run it. 
```console
$ cd alpine/15-slim
$ docker build . -t alpine-pgroonga-15-slim
$ docker run -p 5432:5432 --env POSTGRES_HOST_AUTH_METHOD=trust --env POSTGRES_DB=PGroonga --env POSTGRES_PASSWORD=PGroonga --env POSTGRES_USER=PGroonga alpine-pgroonga-15-slim
```

Connect to the Docker PostgreSQL.
```console
$ psql -h localhost -p 5432 -U PGroonga
```

Check the version and whether we can use PGroonga.
```sql
PGroonga=# SELECT version();
                                                   version                                                    
--------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.1 on x86_64-pc-linux-musl, compiled by gcc (Alpine 11.2.1_git20220219) 11.2.1 20220219, 64-bit
(1 行)

PGroonga=# create extension pgroonga;
CREATE EXTENSION
```

I have done this procedure for each Dockerfiles.