### PR TITLE
Use llvm15

### DIFF
--- a/alpine/11-slim/Dockerfile
+++ b/alpine/11-slim/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev

--- a/alpine/11/Dockerfile
+++ b/alpine/11/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev
@@ -34,4 +34,4 @@ RUN \
     build-base \
     clang \
     clang-dev \
-    llvm13
+    llvm15

--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev

--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev
@@ -34,4 +34,4 @@ RUN \
     build-base \
     clang \
     clang-dev \
-    llvm13
+    llvm15

--- a/alpine/13-slim/Dockerfile
+++ b/alpine/13-slim/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev

--- a/alpine/13/Dockerfile
+++ b/alpine/13/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev
@@ -34,4 +34,4 @@ RUN \
     build-base \
     clang \
     clang-dev \
-    llvm13
+    llvm15

--- a/alpine/14-slim/Dockerfile
+++ b/alpine/14-slim/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev

--- a/alpine/14/Dockerfile
+++ b/alpine/14/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev
@@ -34,4 +34,4 @@ RUN \
     build-base \
     clang \
     clang-dev \
-    llvm13
+    llvm15

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -4,7 +4,7 @@ RUN \
   apk --no-cache add \
     build-base \
     clang-dev \
-    llvm13 \
+    llvm15 \
     lz4-dev \
     msgpack-c-dev \
     zstd-dev
@@ -34,4 +34,4 @@ RUN \
     build-base \
     clang \
     clang-dev \
-    llvm13
+    llvm15


### PR DESCRIPTION
Because there is no llvm13 package available in alpine:3.17.

GitHub: fix #17. Reported by teddybee-r. Thanks!!!
