### PR TITLE
ci build alpine: add workaround for msgpack-c to resolve relative paths

### DIFF
--- a/alpine/build.sh
+++ b/alpine/build.sh
@@ -37,6 +37,13 @@ make -j$(nproc)
 make install
 cd -
 
+# TODO: Remove this workaround after the new msgpack is released.
+# Workaround for msgpack-c to resolve an issue where a prefix path is not reflected.
+sed -i.bak \
+    -E \
+    -e 's,^(include|lib)dir=,\1dir=${prefix}/,g' \
+    /usr/lib/pkgconfig/msgpack-c.pc
+
 wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz
 tar xf groonga-${GROONGA_VERSION}.tar.gz
 cd groonga-${GROONGA_VERSION}


### PR DESCRIPTION
The following error happened when building docker images for Alpine Linux.
- ref: https://github.com/pgroonga/docker/actions/runs/9554591639/job/26335983002

```
  > [linux/amd64 stage-0 4/4] RUN   /build.sh 3.2.0 14.0.2 &&   rm -f build.sh:
366.6 libtool:   error: cannot determine absolute directory name of 'lib'
366.6 make[4]: *** [Makefile:1025: libgroonga.la] Error 1
366.6 make[4]: Leaving directory '/build/groonga-14.0.2/lib'
```

## The cause of this error

Adding `--prefix=/usr/local` during configuration step, we expected the
libdir path like `/user/local/lib`. But the actual path is `/lib` without prefix
because this prefix isn't reflected to pkgconfig file.
This is the same problem is this PR: https://github.com/msgpack/msgpack-c/pull/1119

```console
$ cat /usr/lib/pkgconfig/msgpack-c.pc
prefix=/usr
exec_prefix=/usr
libdir=lib
includedir=include

Name: MessagePack
Description: Binary-based efficient object serialization library
Version: 6.0.1
Libs: -L${libdir} -lmsgpack-c
Cflags: -I${includedir}
```

## Solution
We re-write the msgpack-c.pc which can handle prefix path as a workaround.
This workaround is referred to this commit: https://github.com/groonga/groonga/commit/8275463f7d8f8fc7308b232049fdb0cf538bd3d5.
This problem has already fixed at upstream.
So after new version releasing, we can delete this workaround.
- ref: https://github.com/msgpack/msgpack-c/blob/a5c8a2c845ba43100b7cad7f8a8db0c2ce361d1e/CMakeLists.txt#L33-L42

Additionally, I checked the build step passed here.
- ref: https://github.com/otegami/pgroonga-docker/actions/runs/9610854142/job/26508201198