### PR TITLE
Bump up Groonga from 14.0.2 to 14.0.4

### DIFF
--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/13-slim/Dockerfile
+++ b/alpine/13-slim/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/13/Dockerfile
+++ b/alpine/13/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/14-slim/Dockerfile
+++ b/alpine/14-slim/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/14/Dockerfile
+++ b/alpine/14/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/16-slim/Dockerfile
+++ b/alpine/16-slim/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/16/Dockerfile
+++ b/alpine/16/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \


### PR DESCRIPTION
ref: https://github.com/pgroonga/docker/issues/40

This commit cannot achieve migration from GNU Autotools to CMake. This is a step of it.
We will add the additional changes at the following PRs. Please see also https://github.com/pgroonga/docker/issues/40#issuecomment-2190383938.

## Issue
Groonga v14.0.2 cannot find the `msgpack-c` package during the CMake configuration step.
This issue is due to the absence of changes from the commit [2f01dcce015a6d7cd7f312313d92fd3a5643a4c3](https://github.com/groonga/groonga/commit/2f01dcce015a6d7cd7f312313d92fd3a5643a4c3) in the version we are using.

## Solution
Update Groonga to v14.0.4 which includes the necessary commit to resolve the msgpack-c package finding issue.