### PR TITLE
ci build alpine/12: migrate GNU-Autotools to CMake

### DIFF
--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -2,19 +2,22 @@ FROM postgres:12-alpine
 
 RUN \
   apk --no-cache add \
+    apache-arrow-dev \
     autoconf \
     automake \
     build-base \
     clang15-dev \
+    cmake \
     gettext-dev \
     libtool \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    samurai \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
-    GROONGA_VERSION=14.0.2
+    GROONGA_VERSION=14.0.4
 
 COPY alpine/build.sh /
 RUN \
@@ -28,6 +31,8 @@ RUN \
     build-base \
     clang15 \
     clang15-dev \
+    cmake \
     gettext-dev \
     libtool \
-    llvm15
+    llvm15 \
+    samurai

--- a/alpine/build.sh
+++ b/alpine/build.sh
@@ -40,15 +40,13 @@ cd -
 wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz
 tar xf groonga-${GROONGA_VERSION}.tar.gz
 cd groonga-${GROONGA_VERSION}
-./configure \
-  --prefix=/usr/local \
-  --disable-groonga-httpd \
-  --disable-document \
-  --disable-glibtest \
-  --disable-benchmark \
-  --enable-mruby
-make -j$(nproc)
-make install
+cmake \
+  -S . \
+  -B ../groonga.build \
+  --preset=release-maximum \
+  -DCMAKE_INSTALL_PREFIX=/usr/local
+cmake --build ../groonga.build
+cmake --install ../groonga.build
 cd -
 
 wget https://packages.groonga.org/source/pgroonga/pgroonga-${PGROONGA_VERSION}.tar.gz


### PR DESCRIPTION
ref: https://github.com/pgroonga/docker/issues/40

This commit is a step in the migration from GNU Autotools to CMake.
So this commit will affect the other alpine images but we will fix them at the following PRs.
We will add the additional changes at the following PRs. Please see also https://github.com/pgroonga/docker/issues/40#issuecomment-2190383938.