### PR TITLE
Improve copying of share objects

### DIFF
--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -2,15 +2,18 @@ FROM postgres:12-alpine
 
 RUN \
   apk --no-cache add \
+    apache-arrow-dev \
     autoconf \
     automake \
     build-base \
     clang15-dev \
+    cmake \
     gettext-dev \
     libtool \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    samurai \
     zstd-dev
 
 ENV PGROONGA_VERSION=3.2.0 \
@@ -21,12 +24,26 @@ RUN \
   /build.sh ${PGROONGA_VERSION} ${GROONGA_VERSION} && \
   rm -f build.sh
 
+COPY alpine/create-required-so-tar.sh /
+RUN \
+  /create-required-so-tar.sh && \
+  rm -f /create-required-so-tar.sh
+
 FROM postgres:12-alpine
 
 # copy thirdpart lib files
-COPY --from=0 /usr/lib/libmsgpack-c.so.? /usr/lib/
-COPY --from=0 /usr/lib/liblz4.so.? /usr/lib/
-COPY --from=0 /usr/lib/libzstd.so.? /usr/lib/
+COPY --from=0 /tmp/lib.tar /tmp/
+RUN \
+  tar -xf /tmp/lib.tar -C /lib && \
+  rm -f /tmp/lib.tar
+COPY --from=0 /tmp/usr_lib.tar /tmp/
+RUN \
+  tar -xf /tmp/usr_lib.tar -C /usr/lib && \
+  rm -f /tmp/usr_lib.tar
+COPY --from=0 /tmp/usr_local_lib.tar /tmp/
+RUN \
+  tar -xf /tmp/usr_local_lib.tar -C /usr/local/lib && \
+  rm -f /tmp/usr_local_lib.tar
 # copy MeCab files
 COPY --from=0 /usr/local/etc/mecabrc /usr/local/etc/
 COPY --from=0 /usr/local/lib/libmecab.so.? /usr/local/lib/

--- a/alpine/create-required-so-tar.sh
+++ b/alpine/create-required-so-tar.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eux
+
+lib_files=()
+usr_lib_files=()
+usr_local_lib_files=()
+
+for line in $(ldd /usr/local/lib/postgresql/pgroonga.so 2>/dev/null); do
+  if [ "${line:0:1}" != "/" ]; then
+    continue
+  fi
+  file_name=$(basename "${line}")
+  case $(dirname "${line}") in
+    "/lib")
+      lib_files+=("${file_name}")
+      ;;
+    "/usr/lib")
+      usr_lib_files+=("${file_name}")
+      ;;
+    "/usr/local/lib")
+      usr_local_lib_files+=("${file_name}")
+      ;;
+    *)
+      echo "Unknown path"
+      exit 1
+      ;;
+  esac
+done
+
+tar -chf /tmp/lib.tar -C /lib ${lib_files[@]}
+tar -chf /tmp/usr_lib.tar -C /usr/lib ${usr_lib_files[@]}
+tar -chf /tmp/usr_local_lib.tar -C /usr/local/lib ${usr_local_lib_files[@]}


### PR DESCRIPTION
Groonga is now built by CMake. (GH-46)
More build options and more share objects to depend on.
Since it is not maintainable to `COPY` them individually, copy the share objects we need from the `ldd` results.

Since there are many Dockerfile, only `alpine/12-slim` is updated in this commit.
The other Dockerfile will be updated in another commit.