### PR TITLE
alpine: build MeCab in Groonga build

### DIFF
--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/13-slim/Dockerfile
+++ b/alpine/13-slim/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/13-slim/Dockerfile
+++ b/alpine/13-slim/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/13-slim/Dockerfile
+++ b/alpine/13-slim/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/13/Dockerfile
+++ b/alpine/13/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/13/Dockerfile
+++ b/alpine/13/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/13/Dockerfile
+++ b/alpine/13/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/14-slim/Dockerfile
+++ b/alpine/14-slim/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/14-slim/Dockerfile
+++ b/alpine/14-slim/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/14-slim/Dockerfile
+++ b/alpine/14-slim/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/14/Dockerfile
+++ b/alpine/14/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/14/Dockerfile
+++ b/alpine/14/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/14/Dockerfile
+++ b/alpine/14/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/16-slim/Dockerfile
+++ b/alpine/16-slim/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/16-slim/Dockerfile
+++ b/alpine/16-slim/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/16-slim/Dockerfile
+++ b/alpine/16-slim/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/16/Dockerfile
+++ b/alpine/16/Dockerfile
@@ -15,7 +15,6 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
-    patch \
     rapidjson-dev \
     ruby \
     samurai \

--- a/alpine/16/Dockerfile
+++ b/alpine/16/Dockerfile
@@ -18,7 +18,9 @@ RUN \
     llvm15 \
     lz4-dev \
     msgpack-c-dev \
+    patch \
     rapidjson-dev \
+    ruby \
     samurai \
     xsimd-dev \
     xxhash-dev \

--- a/alpine/16/Dockerfile
+++ b/alpine/16/Dockerfile
@@ -7,13 +7,10 @@ COPY alpine/build.sh /
 RUN \
   apk add --no-cache --virtual=.build-dependencies \
     apache-arrow-dev \
-    autoconf \
-    automake \
     build-base \
     clang15-dev \
     cmake \
     gettext-dev \
-    libtool \
     linux-headers \
     llvm15 \
     lz4-dev \

--- a/alpine/build.sh
+++ b/alpine/build.sh
@@ -8,28 +8,28 @@ GROONGA_VERSION=$2
 MECAB_VERSION=0.996
 
 mkdir build
-cd build
+pushd build
 
 wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz
 tar xf groonga-${GROONGA_VERSION}.tar.gz
 pushd groonga-${GROONGA_VERSION}
 
-cd vendor
+pushd vendor
 wget \
   -O mecab.tar.gz \
   https://packages.groonga.org/source/mecab/mecab-${MECAB_VERSION}.tar.gz
 tar xf mecab.tar.gz
-cd mecab-*
+pushd mecab-*
 sed -i.bak -e 's,ipadic,naist-jdic,g' mecabrc.in
 wget https://github.com/taku910/mecab/pull/71.patch
 patch -p2 < 71.patch
-cd -
+popd
 
 wget \
   -O mecab-naist-jdic.tar.gz \
   https://packages.groonga.org/source/mecab-naist-jdic/mecab-naist-jdic-0.6.3b-20111013.tar.gz
 tar xf mecab-naist-jdic.tar.gz
-cd ..
+popd
 
 cmake \
   -S . \
@@ -42,10 +42,10 @@ popd
 
 wget https://packages.groonga.org/source/pgroonga/pgroonga-${PGROONGA_VERSION}.tar.gz
 tar xf pgroonga-${PGROONGA_VERSION}.tar.gz
-cd pgroonga-${PGROONGA_VERSION}
+pushd pgroonga-${PGROONGA_VERSION}
 make PGRN_DEBUG=yes HAVE_MSGPACK=1 MSGPACK_PACKAGE_NAME=msgpack-c -j$(nproc)
 make install
-cd -
+popd
 
-cd ..
+popd
 rm -rf build

--- a/alpine/build.sh
+++ b/alpine/build.sh
@@ -15,20 +15,7 @@ tar xf groonga-${GROONGA_VERSION}.tar.gz
 pushd groonga-${GROONGA_VERSION}
 
 pushd vendor
-wget \
-  -O mecab.tar.gz \
-  https://packages.groonga.org/source/mecab/mecab-${MECAB_VERSION}.tar.gz
-tar xf mecab.tar.gz
-pushd mecab-*
-sed -i.bak -e 's,ipadic,naist-jdic,g' mecabrc.in
-wget https://github.com/taku910/mecab/pull/71.patch
-patch -p2 < 71.patch
-popd
-
-wget \
-  -O mecab-naist-jdic.tar.gz \
-  https://packages.groonga.org/source/mecab-naist-jdic/mecab-naist-jdic-0.6.3b-20111013.tar.gz
-tar xf mecab-naist-jdic.tar.gz
+ruby download_mecab.rb
 popd
 
 cmake \

--- a/alpine/build.sh
+++ b/alpine/build.sh
@@ -10,6 +10,11 @@ MECAB_VERSION=0.996
 mkdir build
 cd build
 
+wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz
+tar xf groonga-${GROONGA_VERSION}.tar.gz
+pushd groonga-${GROONGA_VERSION}
+
+cd vendor
 wget \
   -O mecab.tar.gz \
   https://packages.groonga.org/source/mecab/mecab-${MECAB_VERSION}.tar.gz
@@ -18,28 +23,14 @@ cd mecab-*
 sed -i.bak -e 's,ipadic,naist-jdic,g' mecabrc.in
 wget https://github.com/taku910/mecab/pull/71.patch
 patch -p2 < 71.patch
-autoreconf --force --install
-./configure --prefix=/usr/local
-make -j$(nproc)
-make install
 cd -
 
 wget \
   -O mecab-naist-jdic.tar.gz \
   https://packages.groonga.org/source/mecab-naist-jdic/mecab-naist-jdic-0.6.3b-20111013.tar.gz
 tar xf mecab-naist-jdic.tar.gz
-cd mecab-naist-jdic-*
-autoreconf --force --install
-./configure \
-  --prefix=/usr/local \
-  --with-charset=utf-8
-make -j$(nproc)
-make install
-cd -
+cd ..
 
-wget https://packages.groonga.org/source/groonga/groonga-${GROONGA_VERSION}.tar.gz
-tar xf groonga-${GROONGA_VERSION}.tar.gz
-cd groonga-${GROONGA_VERSION}
 cmake \
   -S . \
   -B ../groonga.build \
@@ -47,7 +38,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX=/usr/local
 cmake --build ../groonga.build
 cmake --install ../groonga.build
-cd -
+popd
 
 wget https://packages.groonga.org/source/pgroonga/pgroonga-${PGROONGA_VERSION}.tar.gz
 tar xf pgroonga-${PGROONGA_VERSION}.tar.gz


### PR DESCRIPTION
Fix #51

Groonga can build [MeCab](https://taku910.github.io/mecab/) together with CMake.
So we don't have to build MeCab separately in [alpine/build.sh](https://github.com/pgroonga/docker/blob/main/alpine/build.sh).

ref: https://github.com/groonga/groonga/tree/main/vendor/mecab
ref: https://github.com/groonga/groonga/blob/e5ecc368e7825621374d7b0c7662fa455ebd8dd3/CMakeLists.txt#L764-L769