### PR TITLE
alpine/12: Remove lz4 as it is not needed

### DIFF
--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -29,7 +29,6 @@ RUN \
   apk del .build-dependencies && \
   apk add --no-cache \
     libarrow \
-    lz4 \
     msgpack-c \
     libxxhash \
     zlib \


### PR DESCRIPTION
`lz4-libs` is installed dependent on `libarrow`.