### PR TITLE
alpine/12-slim: Remove unused files

### DIFF
--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -32,4 +32,9 @@ RUN \
     msgpack-c \
     libxxhash \
     zlib \
-    zstd
+    zstd && \
+  rm -rf \
+    /usr/local/include \
+    /usr/local/share/man/man.1 \
+    /usr/local/share/groonga/html \
+    /usr/local/lib/mecab/dic/naist-jdic/naist-jdic.csv

--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -35,6 +35,6 @@ RUN \
     zstd && \
   rm -rf \
     /usr/local/include \
-    /usr/local/share/man/man.1 \
+    /usr/local/share/man \
     /usr/local/share/groonga/html \
     /usr/local/lib/mecab/dic/naist-jdic/naist-jdic.csv


### PR DESCRIPTION
```
$ du -hsc \
    /usr/local/include \
    /usr/local/share/man/* \
    /usr/local/share/groonga/html \
    /usr/local/lib/mecab/dic/naist-jdic/naist-jdic.csv
8.4M    /usr/local/include
8.0K    /usr/local/share/man/man1
1.9M    /usr/local/share/groonga/html
54.6M   /usr/local/lib/mecab/dic/naist-jdic/naist-jdic.csv
64.9M   total
```

Image ize
before: 466MB
after: 406MB