### PR TITLE
alpine: bump up Groonga from 14.0.8 to 14.0.9

### DIFF
--- a/alpine/12-slim/Dockerfile
+++ b/alpine/12-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:12-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/12/Dockerfile
+++ b/alpine/12/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:12-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/13-slim/Dockerfile
+++ b/alpine/13-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:13-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/13/Dockerfile
+++ b/alpine/13/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:13-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/14-slim/Dockerfile
+++ b/alpine/14-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:14-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/14/Dockerfile
+++ b/alpine/14/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:14-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/15-slim/Dockerfile
+++ b/alpine/15-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:15-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/15/Dockerfile
+++ b/alpine/15/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:15-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/16-slim/Dockerfile
+++ b/alpine/16-slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:16-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \

--- a/alpine/16/Dockerfile
+++ b/alpine/16/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:16-alpine
 
 ENV PGROONGA_VERSION=3.2.3 \
-    GROONGA_VERSION=14.0.8
+    GROONGA_VERSION=14.0.9
 
 COPY alpine/build.sh /
 RUN \


### PR DESCRIPTION
This PR resolve error when we build docker image for Alpine Linux.