### PR TITLE
alpine: add support for PostgreSQL 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           esac
           tag="groonga/pgroonga:${version}-${{ matrix.id }}"
           tags="${tag}"
-          if [ ${{ matrix.id }} = "alpine-17" -a "${version}" = "latest" ]; then
+          if [ ${{ matrix.id }} = "alpine-18" -a "${version}" = "latest" ]; then
             tags="${tags},groonga/pgroonga:latest"
           fi
           echo "DOCKERFILE=${distribution}/${variant}/Dockerfile" >> ${GITHUB_ENV}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
             docker run \
               --name pgroonga \
               --detach \
+              --env PGDATA=/var/lib/postgresql/${postgresql_version}/docker \
               --env POSTGRES_DB=pgroonga \
               --env POSTGRES_PASSWORD=${PGPASSWORD} \
               --env POSTGRES_USER=pgroonga \
@@ -183,7 +184,7 @@ jobs:
             log_path=pgroonga-$(echo ${platform} | cut -d/ -f2).log
             docker exec pgroonga \
               cp \
-              /var/lib/postgresql/data/pgroonga.log \
+              /var/lib/postgresql/${postgresql_version}/docker/pgroonga.log \
               /host/${log_path}
             sudo chown ${USER}: ${log_path}
             docker kill --signal TERM pgroonga
@@ -203,7 +204,7 @@ jobs:
       - name: Collect logs
         if: always()
         run: |
-          docker exec pgroonga cp /var/lib/postgresql/data/pgroonga.log /host/ || :
+          docker exec pgroonga cp /var/lib/postgresql/${postgresql_version}/docker/pgroonga.log /host/ || :
           sudo chown ${USER}: pgroonga.log || :
       - name: Upload logs
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,13 @@ jobs:
       fail-fast: false
       matrix:
         id:
+          - "alpine-18"
           - "alpine-17"
           - "alpine-16"
           - "alpine-15"
           - "alpine-14"
           - "alpine-13"
+          - "alpine-18-slim"
           - "alpine-17-slim"
           - "alpine-16-slim"
           - "alpine-15-slim"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         id:
+          - "alpine-18"
           - "alpine-17"
           - "alpine-16"
           - "alpine-15"
           - "alpine-14"
           - "alpine-13"
+          - "alpine-18-slim"
           - "alpine-17-slim"
           - "alpine-16-slim"
           - "alpine-15-slim"

--- a/alpine/18-slim/Dockerfile
+++ b/alpine/18-slim/Dockerfile
@@ -1,0 +1,39 @@
+FROM postgres:18-alpine
+
+ENV PGROONGA_VERSION=4.0.4 \
+    GROONGA_VERSION=15.1.7
+
+COPY alpine/build.sh /
+RUN \
+  apk add --no-cache --virtual=.build-dependencies \
+    apache-arrow-dev \
+    build-base \
+    clang19-dev \
+    cmake \
+    gettext-dev \
+    linux-headers \
+    llvm19 \
+    lz4-dev \
+    msgpack-c-dev \
+    rapidjson-dev \
+    ruby \
+    samurai \
+    xsimd-dev \
+    xxhash-dev \
+    zlib-dev \
+    zstd-dev && \
+  /build.sh ${PGROONGA_VERSION} ${GROONGA_VERSION} && \
+  rm -f build.sh && \
+  apk del .build-dependencies && \
+  apk add --no-cache \
+    libarrow \
+    libgomp \
+    libxxhash \
+    msgpack-c \
+    zlib \
+    zstd && \
+  rm -rf \
+    /usr/local/include \
+    /usr/local/lib/mecab/dic/naist-jdic/naist-jdic.csv \
+    /usr/local/share/groonga/html \
+    /usr/local/share/man

--- a/alpine/18/Dockerfile
+++ b/alpine/18/Dockerfile
@@ -1,0 +1,34 @@
+FROM postgres:18-alpine
+
+ENV PGROONGA_VERSION=4.0.4 \
+    GROONGA_VERSION=15.1.7
+
+COPY alpine/build.sh /
+RUN \
+  apk add --no-cache --virtual=.build-dependencies \
+    apache-arrow-dev \
+    build-base \
+    clang19-dev \
+    cmake \
+    gettext-dev \
+    linux-headers \
+    llvm19 \
+    lz4-dev \
+    msgpack-c-dev \
+    rapidjson-dev \
+    ruby \
+    samurai \
+    xsimd-dev \
+    xxhash-dev \
+    zlib-dev \
+    zstd-dev && \
+  /build.sh ${PGROONGA_VERSION} ${GROONGA_VERSION} && \
+  rm -f build.sh && \
+  apk del .build-dependencies && \
+  apk add --no-cache \
+    libarrow \
+    libgomp \
+    libxxhash \
+    msgpack-c \
+    zlib \
+    zstd


### PR DESCRIPTION
We specify PGDATA explicitly.
Because PGDATA is changed to "/var/lib/postgresql/18/docker" since PostgreSQL 18 image.
See: https://github.com/docker-library/postgres/pull/1259