### PR TITLE
ci test: use latest tag instead of version tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           PGPASSWORD: pgroonga
         run: |
-          tag="${LATEST_VERSION}-${{ matrix.id }}"
+          tag="latest-${{ matrix.id }}"
           docker_image="groonga/pgroonga:${tag}"
           docker run \
             -d \


### PR DESCRIPTION
## Issue

The following error is raised when we want to test no-release images as follows.

```
  tag="${LATEST_VERSION}-debian-17"
  docker_image="groonga/pgroonga:${tag}"
  docker run \
    -d \
    -e POSTGRES_DB=pgroonga \
    -e POSTGRES_PASSWORD=${PGPASSWORD} \
    -e POSTGRES_USER=pgroonga \
    -p 127.0.0.1:5432:5432 \
    ${docker_image}
  shell: /usr/bin/bash -e {0}
  env:
    LATEST_VERSION: 4.0.4
    PGPASSWORD: pgroonga
Unable to find image 'groonga/pgroonga:4.0.4-debian-17' locally
docker: Error response from daemon: manifest for groonga/pgroonga:4.0.4-debian-17 not found: manifest unknown: manifest unknown

Run 'docker run --help' for more information
Error: Process completed with exit code 125.
```
ref: https://github.com/pgroonga/docker/actions/runs/18187593348/job/51775157123

## Cause

The version specific tag (e.g., 4.0.4-debian-16)
doesn't exist until after release, but the latest tag is available when testing.

ref: https://github.com/pgroonga/docker/blob/main/.github/workflows/build.yml#L63-L76

## Fix

We will use the latest tag instead of tag from this PR. And then, we can release the latest image even before releasing the new Docker image version.